### PR TITLE
Fixed the ability for docker to deal with absolute paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ COMPOSE_PROJECT_NAME="crb-dock"
 # Project path
 # -------------------------------------------------------------------
 
-COMPOSE_PROJECT_PATH="${HOME}/code/crb-dock"
+COMPOSE_PROJECT_PATH="${pwd}"
 
 # -------------------------------------------------------------------
 # Application location Path
@@ -30,7 +30,7 @@ APPLICATION=${HOME}/code/
 # For all storage systems.
 # -------------------------------------------------------------------
 
-DATA_SAVE_PATH=${HOME}/.crbdata
+DATA_SAVE_PATH=${COMPOSE_PROJECT_PATH}/data
 
 # -------------------------------------------------------------------
 # PHP version

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@
 COMPOSE_PROJECT_NAME="crb-dock"
 
 # -------------------------------------------------------------------
+# Project path
+# -------------------------------------------------------------------
+
+COMPOSE_PROJECT_PATH="${HOME}/code/crb-dock"
+
+# -------------------------------------------------------------------
 # Application location Path
 # Point to your `/var/www` location.
 # Add :cached after www to fix OSX performance issues
@@ -17,14 +23,14 @@ APPLICATION_LOCATION=/var/www
 # Point to your application code, will be available at `/var/www`.
 # -------------------------------------------------------------------
 
-APPLICATION=../
+APPLICATION=${HOME}/code/
 
 # -------------------------------------------------------------------
 # Data Path:
 # For all storage systems.
 # -------------------------------------------------------------------
 
-DATA_SAVE_PATH=~/.crbdata
+DATA_SAVE_PATH=${HOME}/.crbdata
 
 # -------------------------------------------------------------------
 # PHP version
@@ -54,6 +60,7 @@ WORKSPACE_TIMEZONE=UTC+01:00
 #
 # IonCube is not support when using PHP 8.0 or higher
 # -------------------------------------------------------------------
+PHP_FPM_PATH=${COMPOSE_PROJECT_PATH}/php-fpm/php/
 
 PHP_FPM_INSTALL_BCMATH=false
 PHP_FPM_INSTALL_CALENDAR=false
@@ -80,9 +87,9 @@ PHP_FPM_INSTALL_ZIP_ARCHIVE=false
 
 NGINX_HOST_HTTP_PORT=80
 NGINX_HOST_HTTPS_PORT=443
-NGINX_HOST_LOG_PATH=./logs/nginx/
-NGINX_SITES_PATH=./nginx/sites/
-NGINX_SSL_PATH=./nginx/ssl/
+NGINX_HOST_LOG_PATH=${COMPOSE_PROJECT_PATH}/logs/nginx/
+NGINX_SITES_PATH=${COMPOSE_PROJECT_PATH}/nginx/sites/
+NGINX_SSL_PATH=${COMPOSE_PROJECT_PATH}/nginx/ssl/
 
 # -------------------------------------------------------------------
 # Maria DB
@@ -93,7 +100,7 @@ MARIADB_USER=crb_dock
 MARIADB_PASSWORD=secret
 MARIADB_PORT=3306
 MARIADB_ROOT_PASSWORD=root
-MARIADB_ENTRYPOINT_INITDB=./mariadb/docker-entrypoint-initdb.d
+MARIADB_ENTRYPOINT_INITDB=${COMPOSE_PROJECT_PATH}/mariadb/docker-entrypoint-initdb.d
 
 # -------------------------------------------------------------------
 # Portainer

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ COMPOSE_PROJECT_NAME="crb-dock"
 # Project path
 # -------------------------------------------------------------------
 
-COMPOSE_PROJECT_PATH="${pwd}"
+COMPOSE_PROJECT_PATH="${PWD}"
 
 # -------------------------------------------------------------------
 # Application location Path

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       dockerfile: "Dockerfile-${PHP_VERSION}"
     volumes:
       - ${APPLICATION}:${APPLICATION_LOCATION}
-      - ./php-fpm/php${PHP_VERSION}.ini:/usr/local/etc/php/php.ini
+      - ${PHP_FPM_PATH}${PHP_VERSION}.ini:/usr/local/etc/php/php.ini
     expose:
       - "9000"
       - "9001"


### PR DESCRIPTION
Apparently docker couldn't deal with the setup without having absolute paths, so I added the ability to define the project (crb-dock) folder as a variable based on the $HOME which should work on all Unix based systems, I can't verify if this breaks on windows though.